### PR TITLE
Algolia (DocSearch) new keys

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -143,9 +143,9 @@ const config = {
         additionalLanguages: ['bash', 'diff', 'json'],
       },
       algolia: {
-        appId: "V46LQRE2SP",
-        apiKey: "7d25038e11f40e219b68121a3c20b184",
-        indexName: "0lnetwork",
+        appId: "E8UE0IN6GG",
+        apiKey: "6372b13879569a530272b0bb39cfd108",
+        indexName: "openlibra",
         contextualSearch: true,
         debug: false,
       },


### PR DESCRIPTION
The search bar of the documentation website requires a new key since we have migrated to a new domain. This PR provides the new keys.

Algolia has been configured to crawl the website every day at 3PM UTC.